### PR TITLE
Fix problem with absolute path

### DIFF
--- a/ftpData.c
+++ b/ftpData.c
@@ -160,7 +160,7 @@ int getSafePath(dynamicStringDataType *safePath, char *theDirectoryName, loginDa
     
     if (theDirectoryName[0] == '/')
     {
-        while (theDirectoryNamePointer[0] == '/')
+        while (theDirectoryNamePointer[1] == '/')
             theDirectoryNamePointer++;
 
         //printf("\nMemory data address 2nd call : %lld", memoryTable);


### PR DESCRIPTION
When client gives an absolute path (e.g. '/dir' instead of 'dir') an error happen.
getSafePath() did not leave the first slash when removing unnecessary leading slashes.
Problem solved in very simple manner: all we need is to start from 1-st character instead of 0-th one. Please note, theDirectoryNamePointer points to null-terminated string which length is greater than 0, so there is 1-st element is guaranteed to exist.