### PR TITLE
Implement FORCE_TLS option

### DIFF
--- a/ftpData.h
+++ b/ftpData.h
@@ -92,6 +92,7 @@ struct ftpParameters
     char certificatePath[MAXIMUM_INODE_NAME];
     char privateCertificatePath[MAXIMUM_INODE_NAME];
     int pamAuthEnabled;
+    int forceTLS;
 } typedef ftpParameters_DataType;
     
 struct dynamicStringData

--- a/library/configRead.c
+++ b/library/configRead.c
@@ -490,6 +490,18 @@ static int parseConfigurationFile(ftpParameters_DataType *ftpParameters, DYNV_Ve
        // printf("\nENABLE_PAM_AUTH parameter not found in the configuration file, using the default value: %d", ftpParameters->pamAuthEnabled);
     }
 
+    ftpParameters->forceTLS = 0;
+    searchIndex = searchParameter("FORCE_TLS", parametersVector);
+    if (searchIndex != -1)
+    {
+        if(compareStringCaseInsensitive(((parameter_DataType *) parametersVector->Data[searchIndex])->value, "true", strlen("true")) == 1)
+            ftpParameters->forceTLS = 1;
+    }
+    else
+    {
+        // printf("\FORCE_TLS parameter not found in the configuration file, using the default value: %d", ftpParameters->forceTLS);
+    }
+
     ftpParameters->maximumIdleInactivity = 3600;
     searchIndex = searchParameter("IDLE_MAX_TIMEOUT", parametersVector);
     if (searchIndex != -1)

--- a/uftpd.cfg
+++ b/uftpd.cfg
@@ -38,6 +38,10 @@ PRIVATE_CERTIFICATE_PATH=/etc/uFTP/key.pem
 #and /etc/shadow
 ENABLE_PAM_AUTH = false
 
+# Force usage of the TLS
+# If enabled, only TLS connections will be allowed
+FORCE_TLS = false
+
 #USERS
 #START FROM USER 0 TO XXX
 USER_0 = username


### PR DESCRIPTION
In order to improve security new option added: FORCE_TLS.
When set to true server will not accept connections unless TLS is used.
If one tries to connect without TLS server will respond 534 Policy Requires SSL.
The FORCE_TLS parameter is ignored if program built without SSL/TLS support.