### PR TITLE
Fix bug with infinite logging of the error

### DIFF
--- a/ftpServer.c
+++ b/ftpServer.c
@@ -659,7 +659,7 @@ void runFtpServer(void)
             //Debug print errors
             if (ftpData.clients[processingSock].bufferIndex < 0)
             {
-                //ftpData.clients[processingSock].closeTheClient = 1;
+                closeClient(&ftpData, processingSock);
                 printf("\n1 Errno = %d", errno);
                 perror("1 Error: ");
                 continue;


### PR DESCRIPTION
After an error occurred - close the client socket and log this only one time.